### PR TITLE
Fix parsing with decimals in cultures with comma separator

### DIFF
--- a/GeoLibrary.Unit/IO.Facts/GeoJson/GeoJsonReaderFacts.cs
+++ b/GeoLibrary.Unit/IO.Facts/GeoJson/GeoJsonReaderFacts.cs
@@ -3,6 +3,8 @@ using GeoLibrary.IO.GeoJson;
 using GeoLibrary.Model;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 using Xunit;
 
 namespace GeoLibrary.Unit.IO.Facts.GeoJson
@@ -34,6 +36,31 @@ namespace GeoLibrary.Unit.IO.Facts.GeoJson
 
             var resultGeo = GeoJsonReader.Read(geojson);
             resultGeo.Equals(expectGeo).Should().BeTrue();
+        }
+
+        [Fact]
+        public void If_json_is_valid_point_then_should_return_correct_point_in_different_cultures()
+        {
+            var cultures = new string[] { "en-US", "sv-SE" };
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                foreach (var culture in cultures)
+                {
+                    Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+
+                    const string geojson = "{\"type\": \"Point\",\"coordinates\": [10.1, 20.2]}";
+                    var expectGeo = new Point(10.1, 20.2);
+
+                    var resultGeo = GeoJsonReader.Read(geojson);
+                    resultGeo.Equals(expectGeo).Should().BeTrue();
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
 
         [Fact]

--- a/GeoLibrary.Unit/IO.Facts/Wkt/WktReaderFacts.cs
+++ b/GeoLibrary.Unit/IO.Facts/Wkt/WktReaderFacts.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using FluentAssertions;
 using GeoLibrary.IO.Wkt;
 using GeoLibrary.Model;
@@ -27,6 +29,33 @@ namespace GeoLibrary.Unit.IO.Wkt.Facts
             var resultPoint = WktReader.Read(wkt);
 
             resultPoint.Should().BeEquivalentTo(expectedPoint);
+        }
+
+
+        [Fact]
+        public void If_wkt_is_valid_point_then_should_return_correct_point_in_different_cultures()
+        {
+            var cultures = new string[] { "en-US", "sv-SE" };
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                foreach (var culture in cultures)
+                {
+                    Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+
+                    const string wkt = "POINT (10.1 20.2)";
+                    var expectedPoint = new Point(10.1, 20.2);
+
+                    var resultPoint = WktReader.Read(wkt);
+
+                    resultPoint.Should().BeEquivalentTo(expectedPoint);
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
 
         [Theory]

--- a/GeoLibrary/IO/GeoJson/GeoJsonReader.cs
+++ b/GeoLibrary/IO/GeoJson/GeoJsonReader.cs
@@ -2,6 +2,7 @@
 using GeoLibrary.Model;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -242,7 +243,7 @@ namespace GeoLibrary.IO.GeoJson
             while (IsDigit((char)reader.Peek()))
                 builder.Append((char)reader.Read());
 
-            return builder.Length == 0 ? throw new ArgumentException("Invalid number") : double.Parse(builder.ToString());
+            return builder.Length == 0 ? throw new ArgumentException("Invalid number") : double.Parse(builder.ToString(), CultureInfo.InvariantCulture);
         }
 
         private static Point ReadPoint(TextReader reader, StringBuilder builder, bool verifyBeginning = false)

--- a/GeoLibrary/IO/Wkt/WktReader.cs
+++ b/GeoLibrary/IO/Wkt/WktReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using GeoLibrary.Extension;
@@ -164,7 +165,7 @@ namespace GeoLibrary.IO.Wkt
             while (IsDigit((char)reader.Peek()))
                 builder.Append((char)reader.Read());
 
-            return builder.Length == 0 ? throw new ArgumentException("Invalid number") : double.Parse(builder.ToString());
+            return builder.Length == 0 ? throw new ArgumentException("Invalid number") : double.Parse(builder.ToString(), CultureInfo.InvariantCulture);
         }
 
         private static void SkipWhiteSpaces(TextReader reader)


### PR DESCRIPTION
Use `CultureInfo.InvariantCulture` when parsing double, to allow systems with cultures that default uses comma as decimal separator to parse.

Fixes issue: #1 